### PR TITLE
Fix 3 unobtainable fight Achievements to be possible

### DIFF
--- a/game/v10/scene20.rpy
+++ b/game/v10/scene20.rpy
@@ -41,7 +41,8 @@ label v10_room_mon_night:
             if MessengerService.has_replies(josh):
                 u "(I should reply to Josh.)"
 
-        $ phone.applications.append(simplr_app)
+        if simplr_app not in phone.applications:
+            $ phone.applications.append(simplr_app)
         
         if v10_simplr_known:
             u "(Okay let's check this out.)"

--- a/game/v10/scene8.rpy
+++ b/game/v10/scene8.rpy
@@ -24,8 +24,7 @@ label v10_fight_result:
             scene v10fr2 # TPP. Show close up of MC hands in the air above head, excited face, mouth closed
             with dissolve
 
-            if reaction == 0.5:
-                grant Achievement("lights_out", "Beat Ryan on Hard difficulty at the Brawl")
+            grant Achievement("lights_out", "Beat Ryan at the Brawl")
 
             u "This wasn't just a fight for me, it was a fight for me and my brothers."
 
@@ -122,8 +121,7 @@ label v10_fight_result:
             scene v10fr2
             with dissolve
 
-            if reaction == 0.5:
-                grant Achievement("golden_boy", "Beat Imre on Hard difficulty at the Brawl")
+            grant Achievement("golden_boy", "Beat Imre on Hard difficulty at the Brawl")
 
             u "This wasn't just a fight for me, it was a fight for me and my brothers."
 

--- a/game/v2/v2.rpy
+++ b/game/v2/v2.rpy
@@ -1008,8 +1008,7 @@ label tomFightStart:
     jump v1_tom_walk_away
 
 label youfinish:
-    if reaction == 0.5:
-        grant Achievement("the_notorious", "Win your first fight")
+    grant Achievement("the_notorious", "Win your first fight")
             
     $ wintom = True
 

--- a/game/v6/v6.rpy
+++ b/game/v6/v6.rpy
@@ -7183,7 +7183,7 @@ label v6_fr3josh1:
     scene sfr3jo3
     with dissolve
 
-    jo "Checking out the Wolves. Just wanna see what the fuzz is all about, you know."
+    jo "Checking out the Wolves. Just wanna see what the fuss is all about, you know."
 
     jo "Maybe join if they're cool."
 

--- a/game/v9/scene36.rpy
+++ b/game/v9/scene36.rpy
@@ -66,7 +66,7 @@ label v9_run_w_imre:
 
         if winadam:
             imre "You fought Adam though, and you won."
-        else
+        else:
             imre "You fought Adam though, and well you did more damage than I did."
 
         scene v9rwi5

--- a/game/v9/scene36.rpy
+++ b/game/v9/scene36.rpy
@@ -59,21 +59,30 @@ label v9_run_w_imre:
     scene v9rwi5a
     with dissolve
 
-    if winadam:
-        imre "You fought Adam though, and you won."
+    if winadam or adamdmg > 0:
 
-    elif adamdmg > 0:
-        imre "You fought Adam though, and well you did more damage than I did."
+        scene v9rwi5a
+        with dissolve
 
-    scene v9rwi5
-    with dissolve
+        if winadam:
+            imre "You fought Adam though, and you won."
+        else
+            imre "You fought Adam though, and well you did more damage than I did."
 
-    u "All luck."
+        scene v9rwi5
+        with dissolve
+
+        u "All luck."
+
+        scene v9rwi5a
+        with dissolve
+
+        imre "Sure it was."
 
     scene v9rwi5a
     with dissolve
 
-    imre "Sure it was. But I'm not worried about you. If I get the shit beat out of me my pussy getting days are over."
+    imre "But I'm not worried about you. If I get the shit beat out of me my pussy getting days are over."
 
     scene v9rwi5
     with dissolve


### PR DESCRIPTION
I'm not sure if these are a bug or not, but the current version has 3 fights with Achievements which are no longer obtainable (Tom in v2, and Ryan/Imre in v10). Apparently older versions of the game had fight difficulty levels with varying reaction times, that no longer applies to the current version.

If this is not a bug, please let me know so I can remove this branch.