### PR TITLE
Fix fight Achievements that cannot be obtained

### DIFF
--- a/game/v10/scene8.rpy
+++ b/game/v10/scene8.rpy
@@ -24,8 +24,7 @@ label v10_fight_result:
             scene v10fr2 # TPP. Show close up of MC hands in the air above head, excited face, mouth closed
             with dissolve
 
-            if reaction == 0.5:
-                grant Achievement("lights_out", "Beat Ryan on Hard difficulty at the Brawl")
+            grant Achievement("lights_out", "Beat Ryan at the Brawl")
 
             u "This wasn't just a fight for me, it was a fight for me and my brothers."
 
@@ -122,8 +121,7 @@ label v10_fight_result:
             scene v10fr2
             with dissolve
 
-            if reaction == 0.5:
-                grant Achievement("golden_boy", "Beat Imre on Hard difficulty at the Brawl")
+            grant Achievement("golden_boy", "Beat Imre at the Brawl")
 
             u "This wasn't just a fight for me, it was a fight for me and my brothers."
 

--- a/game/v2/v2.rpy
+++ b/game/v2/v2.rpy
@@ -1008,8 +1008,7 @@ label tomFightStart:
     jump v1_tom_walk_away
 
 label youfinish:
-    if reaction == 0.5:
-        grant Achievement("the_notorious", "Win your first fight")
+    grant Achievement("the_notorious", "Win your first fight")
             
     $ wintom = True
 


### PR DESCRIPTION
I'm not sure if these are a bugs:

The current version of the game has three fights with Achievements that cannot be obtained (Tom in v2, and Ryan/Imre in v10). Apparently older versions of the game had fight difficulty levels with varying reaction times, but reaction no longer applies to the current version.

This PR fixes those bugs -- if they are a bug.  If those aren't a bug, please let me know so I can remove my branch.