### PR TITLE
Ms. Rose should only pull MC aside in Europe if he kissed her before

### DIFF
--- a/game/v11/scene17.rpy
+++ b/game/v11/scene17.rpy
@@ -61,7 +61,7 @@ label v11_arrive_hotel:
 
     ro "Everyone please wait and talk amongst yourselves while we wait on the keys."
     stop music fadeout 3
-    if mc.frat == Frat.WOLVES:
+    if mc.frat == Frat.WOLVES and CharacterService.is_kissed(ms_rose):
         scene v11arrh3
         with dissolve
 


### PR DESCRIPTION
The Europe scene with Ms. Rose ("inappropriate behavior") doesn't make sense if the MC didn't make a move on her (i.e. didn't kiss her) in v10/scene25.

This patch adds the additional criterion that the MC previously kissed Ms. Rose to continue their relationship.